### PR TITLE
Update the issues list headers and add the session creator chip

### DIFF
--- a/src/components/PublicSessions/PublicSessions.js
+++ b/src/components/PublicSessions/PublicSessions.js
@@ -42,6 +42,10 @@ class PublicSessions extends Component {
                       <div>{session.title}
                           <a href={session.url} title="go to session" className="secondary-content"><i className="material-icons">arrow_forward</i></a>
                       </div>
+                      <div className="chip" title={session.name} >
+                          <img src={session.photo} alt="img" />
+                          {session.name}
+                       </div>
                   </li>
               )
           }

--- a/src/pages/Session.js
+++ b/src/pages/Session.js
@@ -95,7 +95,7 @@ class SessionPage extends Component {
                 <div className="row">
                     <div className="input-field col l6 s12">
                         <ul className="collection with-header">
-                            <li className="collection-header"><h4>Unestimated Issues</h4></li>
+                            <li className="collection-header grey lighten-4"><h4>Unestimated</h4></li>
                             {
                                 Object.values(this.state.unestimated).map(issue =>
                                     <UnestimatedIssue owner={this.state.owner} id={issue.id} title={issue.title} estimated={issue.estimated} />
@@ -105,7 +105,7 @@ class SessionPage extends Component {
                     </div>
                     <div className="input-field col l6 s12">
                         <ul className="collection with-header">
-                            <li className="collection-header"><h4>Estimated Issues</h4></li>
+                            <li className="collection-header grey lighten-4"><h4>Estimated</h4></li>
                             {
                                 Object.values(this.state.estimated).map(issue =>
                                     <EstimatedIssue owner={this.state.owner} avg={issue.average} id={issue.id} title={issue.title} estimated={issue.estimated} />


### PR DESCRIPTION
- Add creator chip for public sessions

## Changes

### What's New?
N/A

### What's Improved?
Public sessions now have the creator of the session in a chip so that you can tell who made them. 

### What's Fixed?
N/A

##### Issue(s)
N/A