### PR TITLE
feat: implement async voting on issues

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -16,12 +16,17 @@ service cloud.firestore {
         && request.auth.uid == resource.data.creator_uid;
 
       // Session issues subcollection: members can read and create issues;
-      // only the issue creator can update or delete their issue
+      // only the issue creator can update or delete their issue;
+      // any authenticated user can cast/update their own vote (votes field only)
       match /issues/{issueId} {
         allow read: if request.auth != null;
         allow create: if request.auth != null;
-        allow update, delete: if request.auth != null
+        allow delete: if request.auth != null
           && request.auth.uid == resource.data.creator_uid;
+        allow update: if request.auth != null && (
+          request.auth.uid == resource.data.creator_uid ||
+          request.resource.data.diff(resource.data).affectedKeys().hasOnly(['votes'])
+        );
       }
     }
 

--- a/src/hooks/useIssues.ts
+++ b/src/hooks/useIssues.ts
@@ -9,6 +9,7 @@ import {
   doc,
   serverTimestamp,
   writeBatch,
+  updateDoc,
 } from 'firebase/firestore'
 import { db } from '../lib/firebase'
 import type { User } from 'firebase/auth'
@@ -96,5 +97,16 @@ export function useIssues(sessionId: string | undefined, user: User | null) {
     await batch.commit()
   }
 
-  return { issues, loading, addIssue, deleteIssue, moveIssue }
+  async function castVote(issueId: string, value: string) {
+    if (!sessionId || !user) return
+    await updateDoc(doc(db, 'sessions', sessionId, 'issues', issueId), {
+      [`votes.${user.uid}`]: {
+        value,
+        displayName: user.displayName ?? null,
+        photoURL: user.photoURL ?? null,
+      },
+    })
+  }
+
+  return { issues, loading, addIssue, deleteIssue, moveIssue, castVote }
 }

--- a/src/pages/SessionDetail.tsx
+++ b/src/pages/SessionDetail.tsx
@@ -10,7 +10,7 @@ export default function SessionDetail() {
   const navigate = useNavigate()
   const { user } = useAuth()
   const { session, loading: sessionLoading } = useSession(sessionId)
-  const { issues, loading: issuesLoading, addIssue, deleteIssue, moveIssue } =
+  const { issues, loading: issuesLoading, addIssue, deleteIssue, moveIssue, castVote } =
     useIssues(sessionId, user)
 
   const [showAddModal, setShowAddModal] = useState(false)
@@ -168,9 +168,11 @@ export default function SessionDetail() {
                 index={index}
                 total={issues.length}
                 isOwner={!!isOwner}
+                currentUserId={user?.uid ?? null}
                 onMoveUp={() => moveIssue(issue.id, 'up')}
                 onMoveDown={() => moveIssue(issue.id, 'down')}
                 onDelete={() => setIssueToDelete(issue)}
+                onVote={(value) => castVote(issue.id, value)}
               />
             ))}
           </div>
@@ -358,18 +360,23 @@ export default function SessionDetail() {
   )
 }
 
+const POKER_VALUES = ['1', '2', '3', '5', '8', '13', '21']
+
 interface IssueRowProps {
   issue: Issue
   index: number
   total: number
   isOwner: boolean
+  currentUserId: string | null
   onMoveUp: () => void
   onMoveDown: () => void
   onDelete: () => void
+  onVote: (value: string) => void
 }
 
-function IssueRow({ issue, index, total, isOwner, onMoveUp, onMoveDown, onDelete }: IssueRowProps) {
+function IssueRow({ issue, index, total, isOwner, currentUserId, onMoveUp, onMoveDown, onDelete, onVote }: IssueRowProps) {
   const voters = Object.entries(issue.votes ?? {})
+  const myVote = currentUserId ? issue.votes?.[currentUserId]?.value ?? null : null
 
   return (
     <div
@@ -465,10 +472,49 @@ function IssueRow({ issue, index, total, isOwner, onMoveUp, onMoveDown, onDelete
         )}
         {/* Voter avatars */}
         {voters.length > 0 && (
-          <div style={{ display: 'flex', gap: '0.25rem', marginTop: '0.5rem', flexWrap: 'wrap' }}>
+          <div style={{ display: 'flex', gap: '0.25rem', marginTop: '0.5rem', flexWrap: 'wrap', alignItems: 'center' }}>
             {voters.map(([uid, voter]) => (
-              <VoterAvatar key={uid} displayName={voter.displayName} photoURL={voter.photoURL} />
+              <VoterAvatar
+                key={uid}
+                displayName={voter.displayName}
+                photoURL={voter.photoURL}
+                value={issue.revealed ? (voter.value ?? null) : null}
+              />
             ))}
+          </div>
+        )}
+
+        {/* Voting panel — only shown when not yet revealed */}
+        {!issue.revealed && currentUserId && (
+          <div style={{ display: 'flex', gap: '0.375rem', marginTop: '0.75rem', flexWrap: 'wrap' }}>
+            {POKER_VALUES.map((v) => {
+              const selected = myVote === v
+              return (
+                <button
+                  key={v}
+                  onClick={() => onVote(v)}
+                  title={`Vote ${v}`}
+                  style={{
+                    width: '2.25rem',
+                    height: '3rem',
+                    border: selected
+                      ? '2px solid var(--color-primary)'
+                      : '1px solid var(--color-border)',
+                    borderRadius: '0.375rem',
+                    backgroundColor: selected
+                      ? 'var(--color-primary)'
+                      : 'var(--color-surface-elevated)',
+                    color: selected ? '#fff' : 'var(--color-text-secondary)',
+                    fontSize: '0.875rem',
+                    fontWeight: selected ? 700 : 400,
+                    cursor: 'pointer',
+                    transition: 'background-color 0.1s, border-color 0.1s, color 0.1s',
+                  }}
+                >
+                  {v}
+                </button>
+              )
+            })}
           </div>
         )}
       </div>
@@ -497,31 +543,29 @@ function IssueRow({ issue, index, total, isOwner, onMoveUp, onMoveDown, onDelete
   )
 }
 
-function VoterAvatar({ displayName, photoURL }: { displayName: string | null; photoURL: string | null }) {
+function VoterAvatar({ displayName, photoURL, value }: { displayName: string | null; photoURL: string | null; value: string | null }) {
   const initials = displayName
     ? displayName.split(' ').map((n) => n[0]).slice(0, 2).join('').toUpperCase()
     : '?'
+  const title = value != null
+    ? `${displayName ?? 'Voter'}: ${value}`
+    : (displayName ?? 'Voter')
 
-  if (photoURL) {
-    return (
-      <img
-        src={photoURL}
-        alt={displayName ?? 'Voter'}
-        title={displayName ?? 'Voter'}
-        style={{
-          width: '24px',
-          height: '24px',
-          borderRadius: '50%',
-          border: '1px solid var(--color-border)',
-          objectFit: 'cover',
-        }}
-      />
-    )
-  }
-
-  return (
+  const avatar = photoURL ? (
+    <img
+      src={photoURL}
+      alt={displayName ?? 'Voter'}
+      style={{
+        width: '24px',
+        height: '24px',
+        borderRadius: '50%',
+        border: '1px solid var(--color-border)',
+        objectFit: 'cover',
+        flexShrink: 0,
+      }}
+    />
+  ) : (
     <div
-      title={displayName ?? 'Voter'}
       style={{
         width: '24px',
         height: '24px',
@@ -539,4 +583,17 @@ function VoterAvatar({ displayName, photoURL }: { displayName: string | null; ph
       {initials}
     </div>
   )
+
+  if (value != null) {
+    return (
+      <div title={title} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '0.125rem' }}>
+        {avatar}
+        <span style={{ fontSize: '0.625rem', fontWeight: 700, color: 'var(--color-text-secondary)', lineHeight: 1 }}>
+          {value}
+        </span>
+      </div>
+    )
+  }
+
+  return <div title={title}>{avatar}</div>
 }


### PR DESCRIPTION
Implements planning poker voting on issues (scale: 1, 2, 3, 5, 8, 13, 21).

- Any authenticated user can cast or change their vote on an un-revealed issue
- Votes are stored as upserts keyed by userId in Firestore
- Vote values are never shown until the issue is revealed
- Voter avatar appears as soon as a vote is cast; value badge appears after reveal
- Firestore rules updated to allow vote-only writes from any authenticated user

Closes #108

Generated with [Claude Code](https://claude.ai/code)