### PR TITLE
fix: dashboard does not load existing sessions

### DIFF
--- a/src/hooks/useSessions.ts
+++ b/src/hooks/useSessions.ts
@@ -21,17 +21,21 @@ export interface Session {
   createdAt: { toMillis: () => number } | null
 }
 
-export function useSessions(user: User | null) {
+export function useSessions(user: User | null, authLoading = false) {
   const [sessions, setSessions] = useState<Session[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
+    if (authLoading) return
+
     if (!user) {
       setSessions([])
       setLoading(false)
       return
     }
+
+    setLoading(true)
 
     const q = query(
       collection(db, 'sessions'),
@@ -57,7 +61,7 @@ export function useSessions(user: User | null) {
     )
 
     return unsubscribe
-  }, [user])
+  }, [user?.uid, authLoading])
 
   return { sessions, loading, error }
 }

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -7,8 +7,8 @@ import { useSessions } from '../hooks/useSessions'
 import type { Session } from '../hooks/useSessions'
 
 export default function Dashboard() {
-  const { user, signOut } = useAuth()
-  const { sessions, loading, error } = useSessions(user)
+  const { user, loading: authLoading, signOut } = useAuth()
+  const { sessions, loading, error } = useSessions(user, authLoading)
   const navigate = useNavigate()
   const [showCreateModal, setShowCreateModal] = useState(false)
   const [newSessionName, setNewSessionName] = useState('')


### PR DESCRIPTION
Fixes #124

## Problem

The `useSessions` hook set `loading:false` immediately when `user` was `null` (while Firebase Auth was still resolving). On navigation back to the dashboard the component re-mounted fresh with `user:null`, instantly flipped to the empty state, and sessions never visibly loaded.

## Fix

- Pass `authLoading` from `useAuth` into `useSessions`; the effect is a no-op while auth is still resolving
- Reset `loading:true` before each new Firestore listener setup
- Depend on `user?.uid` instead of the full `user` object to avoid spurious re-subscriptions on token refresh

Generated with [Claude Code](https://claude.ai/code)