### PR TITLE
fix: dashboard does not load existing sessions

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -16,8 +16,8 @@ interface AuthState {
 }
 
 export function useAuth(): AuthState {
-  const [user, setUser] = useState<User | null>(null)
-  const [loading, setLoading] = useState(true)
+  const [user, setUser] = useState<User | null>(auth.currentUser)
+  const [loading, setLoading] = useState(!auth.currentUser)
 
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, (currentUser) => {

--- a/src/hooks/useSessions.ts
+++ b/src/hooks/useSessions.ts
@@ -4,7 +4,6 @@ import {
   query,
   where,
   onSnapshot,
-  orderBy,
 } from 'firebase/firestore'
 import { db } from '../lib/firebase'
 import type { User } from 'firebase/auth'
@@ -40,16 +39,14 @@ export function useSessions(user: User | null, authLoading = false) {
     const q = query(
       collection(db, 'sessions'),
       where('memberIds', 'array-contains', user.uid),
-      orderBy('createdAt', 'desc'),
     )
 
     const unsubscribe = onSnapshot(
       q,
       (snapshot) => {
-        const list = snapshot.docs.map((doc) => ({
-          id: doc.id,
-          ...(doc.data() as Omit<Session, 'id'>),
-        }))
+        const list = snapshot.docs
+          .map((doc) => ({ id: doc.id, ...(doc.data() as Omit<Session, 'id'>) }))
+          .sort((a, b) => (b.createdAt?.toMillis() ?? 0) - (a.createdAt?.toMillis() ?? 0))
         setSessions(list)
         setLoading(false)
         setError(null)


### PR DESCRIPTION
Fixes #124

## Root Causes

1. `useAuth` initialized from `null` instead of `auth.currentUser` — caused an async gap on every navigation where the Firestore listener was not set up until Firebase's `onAuthStateChanged` fired
2. Firestore query used `array-contains` + `orderBy` on different fields without a deployed composite index, causing the `onSnapshot` error callback to fire

## Fix

- Initialize `useAuth` state from `auth.currentUser` so returning to the dashboard immediately has the authenticated user
- Remove `orderBy` from the Firestore sessions query and sort client-side instead

Generated with [Claude Code](https://claude.ai/code)