### PR TITLE
chore: rename Session to Backlog and sort issues by reveal status

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -70,7 +70,7 @@ export default function Dashboard() {
         {/* Header */}
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '2rem' }}>
           <h1 style={{ margin: 0, fontSize: '1.5rem', fontWeight: 600, color: 'var(--color-text-primary)' }}>
-            Sessions
+            Point-Poker Backlogs
           </h1>
           <div style={{ display: 'flex', gap: '0.75rem', alignItems: 'center' }}>
             <button
@@ -86,7 +86,7 @@ export default function Dashboard() {
                 cursor: 'pointer',
               }}
             >
-              + Create session
+              + Create backlog
             </button>
             <button
               onClick={signOut}
@@ -107,7 +107,7 @@ export default function Dashboard() {
 
         {/* Session list */}
         {loading ? (
-          <p style={{ color: 'var(--color-text-secondary)' }}>Loading sessions…</p>
+          <p style={{ color: 'var(--color-text-secondary)' }}>Loading backlogs…</p>
         ) : error ? (
           <div
             style={{
@@ -131,7 +131,7 @@ export default function Dashboard() {
               color: 'var(--color-text-muted)',
             }}
           >
-            <p style={{ marginBottom: '0.75rem' }}>No sessions yet.</p>
+            <p style={{ marginBottom: '0.75rem' }}>No backlogs yet.</p>
             <button
               onClick={openCreateModal}
               style={{
@@ -142,7 +142,7 @@ export default function Dashboard() {
                 cursor: 'pointer',
               }}
             >
-              Create your first session →
+              Create your first backlog →
             </button>
           </div>
         ) : (
@@ -184,7 +184,7 @@ export default function Dashboard() {
                   {user && session.creator_uid === user.uid && (
                     <button
                       onClick={(e) => { e.stopPropagation(); setSessionToDelete(session) }}
-                      title="Delete session"
+                      title="Delete backlog"
                       style={{
                         marginLeft: '0.5rem',
                         flexShrink: 0,
@@ -227,7 +227,7 @@ export default function Dashboard() {
         <div
           role="dialog"
           aria-modal="true"
-          aria-label="Create session"
+          aria-label="Create backlog"
           onClick={(e) => { if (e.target === e.currentTarget) closeCreateModal() }}
           style={{
             position: 'fixed',
@@ -250,11 +250,11 @@ export default function Dashboard() {
             }}
           >
             <h2 style={{ margin: '0 0 1rem 0', fontSize: '1.125rem', fontWeight: 600, color: 'var(--color-text-primary)' }}>
-              Create session
+              Create backlog
             </h2>
             <input
               type="text"
-              placeholder="Session name"
+              placeholder="Backlog name"
               value={newSessionName}
               onChange={(e) => setNewSessionName(e.target.value)}
               onKeyDown={(e) => { if (e.key === 'Enter') createSession() }}
@@ -314,7 +314,7 @@ export default function Dashboard() {
         <div
           role="dialog"
           aria-modal="true"
-          aria-label="Delete session"
+          aria-label="Delete backlog"
           onClick={(e) => { if (e.target === e.currentTarget) closeDeleteModal() }}
           style={{
             position: 'fixed',
@@ -337,7 +337,7 @@ export default function Dashboard() {
             }}
           >
             <h2 style={{ margin: '0 0 0.5rem 0', fontSize: '1.125rem', fontWeight: 600, color: 'var(--color-text-primary)' }}>
-              Delete session?
+              Delete backlog?
             </h2>
             <p style={{ margin: '0 0 1.25rem 0', fontSize: '0.875rem', color: 'var(--color-text-secondary)' }}>
               "{sessionToDelete.name}" will be permanently deleted. This cannot be undone.

--- a/src/pages/SessionDetail.tsx
+++ b/src/pages/SessionDetail.tsx
@@ -241,7 +241,7 @@ export default function SessionDetail() {
               color: 'var(--color-warning)',
             }}
           >
-            You are viewing this session as a guest and cannot vote. Ask the session owner for an invite link to join.
+            You are viewing this backlog as a guest and cannot vote. Ask the backlog owner for an invite link to join.
           </div>
         )}
 
@@ -289,12 +289,37 @@ export default function SessionDetail() {
           </div>
         ) : (
           <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
-            {issues.map((issue, index) => (
+            {issues.filter(i => !i.revealed).map((issue, index) => (
               <IssueRow
                 key={issue.id}
                 issue={issue}
                 index={index}
-                total={issues.length}
+                total={issues.filter(i => !i.revealed).length}
+                isOwner={!!isOwner}
+                isMember={!!isMember}
+                currentUserId={user?.uid ?? null}
+                onMoveUp={() => moveIssue(issue.id, 'up')}
+                onMoveDown={() => moveIssue(issue.id, 'down')}
+                onDelete={() => setIssueToDelete(issue)}
+                onVote={(value) => castVote(issue.id, value)}
+                onReveal={() => revealVotes(issue.id)}
+              />
+            ))}
+            {issues.some(i => i.revealed) && issues.some(i => !i.revealed) && (
+              <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', padding: '0.25rem 0' }}>
+                <div style={{ flex: 1, height: '1px', backgroundColor: 'var(--color-border-default)' }} />
+                <span style={{ fontSize: '0.6875rem', fontWeight: 600, color: 'var(--color-text-muted)', letterSpacing: '0.05em', textTransform: 'uppercase' }}>
+                  Revealed
+                </span>
+                <div style={{ flex: 1, height: '1px', backgroundColor: 'var(--color-border-default)' }} />
+              </div>
+            )}
+            {issues.filter(i => i.revealed).map((issue, index) => (
+              <IssueRow
+                key={issue.id}
+                issue={issue}
+                index={index}
+                total={issues.filter(i => i.revealed).length}
                 isOwner={!!isOwner}
                 isMember={!!isMember}
                 currentUserId={user?.uid ?? null}
@@ -340,7 +365,7 @@ export default function SessionDetail() {
               Invite teammates
             </h2>
             <p style={{ margin: '0 0 1rem 0', fontSize: '0.875rem', color: 'var(--color-text-secondary)' }}>
-              Share this link to invite others to vote in this session. Anyone with the link can join.
+              Share this link to invite others to vote in this backlog. Anyone with the link can join.
             </p>
             {generatingToken ? (
               <p style={{ fontSize: '0.875rem', color: 'var(--color-text-muted)' }}>Generating invite link…</p>
@@ -664,10 +689,11 @@ function IssueRow({ issue, index, total, isOwner, isMember, currentUserId, onMov
         display: 'flex',
         alignItems: 'flex-start',
         gap: '0.75rem',
+        opacity: issue.revealed ? 0.65 : 1,
       }}
     >
       {/* Reorder buttons */}
-      {isOwner && (
+      {isOwner && !issue.revealed && (
         <div style={{ display: 'flex', flexDirection: 'column', gap: '0.125rem', flexShrink: 0, paddingTop: '0.125rem' }}>
           <button
             onClick={onMoveUp}


### PR DESCRIPTION
Two related UI/UX improvements:

1. Renamed all user-facing "Session" labels to "Backlog" throughout Dashboard (heading, create/delete buttons, modals, placeholders, loading text) and updated guest notice / invite modal copy in SessionDetail. Variable names and Firestore collection names are unchanged.

2. Issues within a backlog are now sorted so unrevealed (open) issues always appear above revealed issues. A labeled divider separates the two groups. Revealed issues are rendered at 65% opacity and their reorder buttons are hidden.

Closes #137

Generated with [Claude Code](https://claude.ai/code)