### PR TITLE
fix: extract roundUpToFibonacci to utility and add unit tests

### DIFF
--- a/src/lib/fibonacci.test.ts
+++ b/src/lib/fibonacci.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { roundUpToFibonacci } from './fibonacci'
+
+describe('roundUpToFibonacci', () => {
+  it('returns exact Fibonacci numbers unchanged', () => {
+    expect(roundUpToFibonacci(1)).toBe(1)
+    expect(roundUpToFibonacci(2)).toBe(2)
+    expect(roundUpToFibonacci(3)).toBe(3)
+    expect(roundUpToFibonacci(5)).toBe(5)
+    expect(roundUpToFibonacci(8)).toBe(8)
+    expect(roundUpToFibonacci(13)).toBe(13)
+    expect(roundUpToFibonacci(21)).toBe(21)
+  })
+
+  it('rounds up to the nearest Fibonacci number for the examples in issue #139', () => {
+    expect(roundUpToFibonacci(1.0)).toBe(1)
+    expect(roundUpToFibonacci(1.1)).toBe(2)
+    expect(roundUpToFibonacci(1.5)).toBe(2)
+    expect(roundUpToFibonacci(2.0)).toBe(2)
+    expect(roundUpToFibonacci(2.1)).toBe(3)
+    expect(roundUpToFibonacci(3.5)).toBe(5)
+    expect(roundUpToFibonacci(4.0)).toBe(5)
+    expect(roundUpToFibonacci(6.0)).toBe(8)
+  })
+
+  it('caps at 21 for averages above 21', () => {
+    expect(roundUpToFibonacci(21.1)).toBe(21)
+    expect(roundUpToFibonacci(22)).toBe(21)
+    expect(roundUpToFibonacci(100)).toBe(21)
+  })
+})

--- a/src/lib/fibonacci.ts
+++ b/src/lib/fibonacci.ts
@@ -1,0 +1,8 @@
+export const FIBONACCI = [1, 2, 3, 5, 8, 13, 21]
+
+export function roundUpToFibonacci(n: number): number {
+  for (const f of FIBONACCI) {
+    if (f >= n) return f
+  }
+  return FIBONACCI[FIBONACCI.length - 1]
+}

--- a/src/pages/SessionDetail.tsx
+++ b/src/pages/SessionDetail.tsx
@@ -6,6 +6,7 @@ import { useAuth } from '../hooks/useAuth'
 import { useSession } from '../hooks/useSession'
 import { useIssues } from '../hooks/useIssues'
 import type { Issue } from '../hooks/useIssues'
+import { roundUpToFibonacci } from '../lib/fibonacci'
 
 export default function SessionDetail() {
   const { sessionId } = useParams<{ sessionId: string }>()
@@ -641,15 +642,6 @@ function getExternalLinkLabel(url: string): string {
 }
 
 const POKER_VALUES = ['1', '2', '3', '5', '8', '13', '21']
-
-const FIBONACCI = [1, 2, 3, 5, 8, 13, 21]
-
-function roundUpToFibonacci(n: number): number {
-  for (const f of FIBONACCI) {
-    if (f >= n) return f
-  }
-  return FIBONACCI[FIBONACCI.length - 1]
-}
 
 interface IssueRowProps {
   issue: Issue


### PR DESCRIPTION
Moves the Fibonacci ceiling logic from SessionDetail.tsx into a dedicated src/lib/fibonacci.ts utility so it can be properly unit-tested. Adds a Vitest test file covering all examples from #139, including exact Fibonacci values, rounding-up cases, and the 21-cap behaviour.

Closes #139

Generated with [Claude Code](https://claude.ai/code)