### PR TITLE
feat: update voting scale to 1-8 and add floating readiness guide

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "vitest"
   },
   "dependencies": {
+    "@heroicons/react": "^2.0.0",
     "firebase": "^11.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/src/components/ReadinessGuide.tsx
+++ b/src/components/ReadinessGuide.tsx
@@ -1,0 +1,157 @@
+import { useState } from 'react'
+import { BookOpenIcon } from '@heroicons/react/24/outline'
+
+const READINESS_SCALE = [
+  {
+    value: 1,
+    label: 'Fully defined',
+    description: 'Clear acceptance criteria, right-sized, no open questions. Ready for Claude to implement immediately.',
+  },
+  {
+    value: 2,
+    label: 'Mostly clear',
+    description: "Minor ambiguity that probably won't block implementation. Roughly right-sized.",
+  },
+  {
+    value: 3,
+    label: 'Some gaps',
+    description: 'Needs a small discussion or some breakdown before handing off.',
+  },
+  {
+    value: 5,
+    label: 'Significant ambiguity',
+    description: 'Needs breakdown into smaller, right-sized pieces or more definition.',
+  },
+  {
+    value: 8,
+    label: 'Not ready',
+    description: 'Major open questions, dependencies, or scope issues. Not right-sized.',
+  },
+]
+
+export function ReadinessGuide() {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        title="Readiness guide"
+        aria-label="Open readiness guide"
+        style={{
+          position: 'fixed',
+          bottom: '1.5rem',
+          right: '1.5rem',
+          width: '2.5rem',
+          height: '2.5rem',
+          borderRadius: '50%',
+          border: '1px solid var(--color-border-default)',
+          backgroundColor: 'var(--color-bg-elevated)',
+          color: 'var(--color-text-muted)',
+          cursor: 'pointer',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          zIndex: 40,
+          transition: 'border-color 0.15s, color 0.15s',
+        }}
+        onMouseEnter={(e) => {
+          e.currentTarget.style.borderColor = 'var(--color-border-active)'
+          e.currentTarget.style.color = 'var(--color-text-secondary)'
+        }}
+        onMouseLeave={(e) => {
+          e.currentTarget.style.borderColor = 'var(--color-border-default)'
+          e.currentTarget.style.color = 'var(--color-text-muted)'
+        }}
+      >
+        <BookOpenIcon style={{ width: '1.125rem', height: '1.125rem' }} />
+      </button>
+
+      {open && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="Readiness guide"
+          onClick={(e) => { if (e.target === e.currentTarget) setOpen(false) }}
+          style={{
+            position: 'fixed',
+            inset: 0,
+            backgroundColor: 'var(--color-overlay)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            zIndex: 50,
+          }}
+        >
+          <div
+            style={{
+              backgroundColor: 'var(--color-bg-elevated)',
+              border: '1px solid var(--color-border-default)',
+              borderRadius: '0.75rem',
+              padding: '1.5rem',
+              width: '100%',
+              maxWidth: '480px',
+            }}
+          >
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '0.75rem' }}>
+              <h2 style={{ margin: 0, fontSize: '1.125rem', fontWeight: 600, color: 'var(--color-text-primary)' }}>
+                Readiness scale
+              </h2>
+              <button
+                onClick={() => setOpen(false)}
+                aria-label="Close"
+                style={{
+                  background: 'none',
+                  border: 'none',
+                  color: 'var(--color-text-muted)',
+                  cursor: 'pointer',
+                  padding: '0.25rem',
+                  fontSize: '1rem',
+                  lineHeight: 1,
+                  borderRadius: '0.25rem',
+                }}
+              >
+                ✕
+              </button>
+            </div>
+            <p style={{ margin: '0 0 1.25rem 0', fontSize: '0.8125rem', color: 'var(--color-text-secondary)' }}>
+              Vote on how ready each issue is for AI-assisted implementation.
+            </p>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.875rem' }}>
+              {READINESS_SCALE.map(({ value, label, description }) => (
+                <div key={value} style={{ display: 'flex', gap: '0.875rem', alignItems: 'flex-start' }}>
+                  <span
+                    style={{
+                      flexShrink: 0,
+                      width: '1.75rem',
+                      height: '1.75rem',
+                      borderRadius: '0.375rem',
+                      backgroundColor: 'var(--color-bg-surface)',
+                      border: '1px solid var(--color-border-default)',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      fontSize: '0.875rem',
+                      fontWeight: 700,
+                      color: 'var(--color-primary)',
+                    }}
+                  >
+                    {value}
+                  </span>
+                  <div>
+                    <div style={{ fontSize: '0.875rem', fontWeight: 600, color: 'var(--color-text-primary)', marginBottom: '0.125rem' }}>
+                      {label}
+                    </div>
+                    <div style={{ fontSize: '0.8125rem', color: 'var(--color-text-secondary)' }}>
+                      {description}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/src/lib/fibonacci.test.ts
+++ b/src/lib/fibonacci.test.ts
@@ -8,8 +8,6 @@ describe('roundUpToFibonacci', () => {
     expect(roundUpToFibonacci(3)).toBe(3)
     expect(roundUpToFibonacci(5)).toBe(5)
     expect(roundUpToFibonacci(8)).toBe(8)
-    expect(roundUpToFibonacci(13)).toBe(13)
-    expect(roundUpToFibonacci(21)).toBe(21)
   })
 
   it('rounds up to the nearest Fibonacci number for the examples in issue #139', () => {
@@ -23,9 +21,10 @@ describe('roundUpToFibonacci', () => {
     expect(roundUpToFibonacci(6.0)).toBe(8)
   })
 
-  it('caps at 21 for averages above 21', () => {
-    expect(roundUpToFibonacci(21.1)).toBe(21)
-    expect(roundUpToFibonacci(22)).toBe(21)
-    expect(roundUpToFibonacci(100)).toBe(21)
+  it('caps at 8 for averages above 8', () => {
+    expect(roundUpToFibonacci(8.1)).toBe(8)
+    expect(roundUpToFibonacci(13)).toBe(8)
+    expect(roundUpToFibonacci(21)).toBe(8)
+    expect(roundUpToFibonacci(100)).toBe(8)
   })
 })

--- a/src/lib/fibonacci.ts
+++ b/src/lib/fibonacci.ts
@@ -1,4 +1,4 @@
-export const FIBONACCI = [1, 2, 3, 5, 8, 13, 21]
+export const FIBONACCI = [1, 2, 3, 5, 8]
 
 export function roundUpToFibonacci(n: number): number {
   for (const f of FIBONACCI) {

--- a/src/pages/SessionDetail.tsx
+++ b/src/pages/SessionDetail.tsx
@@ -7,6 +7,7 @@ import { useSession } from '../hooks/useSession'
 import { useIssues } from '../hooks/useIssues'
 import type { Issue } from '../hooks/useIssues'
 import { roundUpToFibonacci } from '../lib/fibonacci'
+import { ReadinessGuide } from '../components/ReadinessGuide'
 
 export default function SessionDetail() {
   const { sessionId } = useParams<{ sessionId: string }>()
@@ -624,6 +625,8 @@ export default function SessionDetail() {
           </div>
         </div>
       )}
+
+      <ReadinessGuide />
     </div>
   )
 }
@@ -641,7 +644,7 @@ function getExternalLinkLabel(url: string): string {
   }
 }
 
-const POKER_VALUES = ['1', '2', '3', '5', '8', '13', '21']
+const POKER_VALUES = ['1', '2', '3', '5', '8']
 
 interface IssueRowProps {
   issue: Issue


### PR DESCRIPTION
Two related changes per issue #141:

- Remove 13 and 21 from the voting scale; valid values are now 1, 2, 3, 5, 8
- Add floating readiness guide button + modal to the backlog view

**Data model changes:** None

**Assumptions:** @heroicons/react added to package.json; run `npm install` after checkout

Closes #141

Generated with [Claude Code](https://claude.ai/code)