### PR TITLE
feat: add issues from links

### DIFF
--- a/src/hooks/useIssues.ts
+++ b/src/hooks/useIssues.ts
@@ -92,6 +92,34 @@ export function useIssues(sessionId: string | undefined, user: User | null) {
     })
   }
 
+  async function addIssues(items: Array<{ title: string; externalUrl?: string }>) {
+    if (!sessionId || !user || items.length === 0) return
+    const startOrder =
+      issues.length > 0 ? Math.max(...issues.map((i) => i.order)) + 1 : 0
+    const batch = writeBatch(db)
+    const issuesCol = collection(db, 'sessions', sessionId, 'issues')
+    items.forEach((item, idx) => {
+      const ref = doc(issuesCol)
+      const issueData: Record<string, unknown> = {
+        title: item.title.trim(),
+        description: '',
+        order: startOrder + idx,
+        revealed: false,
+        votes: {},
+        creator_uid: user.uid,
+        createdAt: serverTimestamp(),
+      }
+      if (item.externalUrl?.trim()) {
+        issueData.externalUrl = item.externalUrl.trim()
+      }
+      batch.set(ref, issueData)
+    })
+    batch.update(doc(db, 'sessions', sessionId), {
+      openIssues: increment(items.length),
+    })
+    await batch.commit()
+  }
+
   async function deleteIssue(issueId: string) {
     if (!sessionId) return
     const issue = issues.find((i) => i.id === issueId)
@@ -155,5 +183,5 @@ export function useIssues(sessionId: string | undefined, user: User | null) {
     })
   }
 
-  return { issues, loading, error, addIssue, deleteIssue, moveIssue, castVote, revealVotes, reopenIssue }
+  return { issues, loading, error, addIssue, addIssues, deleteIssue, moveIssue, castVote, revealVotes, reopenIssue }
 }

--- a/src/lib/parseIssueUrl.test.ts
+++ b/src/lib/parseIssueUrl.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest'
+import { parseIssueUrl, parseIssueUrls } from './parseIssueUrl'
+
+describe('parseIssueUrl', () => {
+  it('parses GitHub issue URLs with https', () => {
+    expect(parseIssueUrl('https://github.com/org/repo/issues/123')).toEqual({
+      title: 'org/repo #123',
+      externalUrl: 'https://github.com/org/repo/issues/123',
+    })
+  })
+
+  it('parses GitHub issue URLs without protocol', () => {
+    expect(parseIssueUrl('github.com/org/repo/issues/42')).toEqual({
+      title: 'org/repo #42',
+      externalUrl: 'github.com/org/repo/issues/42',
+    })
+  })
+
+  it('parses Linear issue URLs (singular /issue/)', () => {
+    expect(parseIssueUrl('https://linear.app/myteam/issue/KEY-456')).toEqual({
+      title: 'KEY-456',
+      externalUrl: 'https://linear.app/myteam/issue/KEY-456',
+    })
+  })
+
+  it('parses Linear issue URLs (plural /issues/)', () => {
+    expect(parseIssueUrl('https://linear.app/myteam/issues/ENG-789')).toEqual({
+      title: 'ENG-789',
+      externalUrl: 'https://linear.app/myteam/issues/ENG-789',
+    })
+  })
+
+  it('parses Jira/Atlassian issue URLs', () => {
+    expect(parseIssueUrl('https://mycompany.atlassian.net/browse/PROJ-456')).toEqual({
+      title: 'PROJ-456',
+      externalUrl: 'https://mycompany.atlassian.net/browse/PROJ-456',
+    })
+  })
+
+  it('uppercases Linear issue key', () => {
+    const result = parseIssueUrl('https://linear.app/team/issue/eng-10')
+    expect(result.title).toBe('ENG-10')
+  })
+
+  it('uppercases Jira issue key', () => {
+    const result = parseIssueUrl('https://corp.atlassian.net/browse/bug-1')
+    expect(result.title).toBe('BUG-1')
+  })
+
+  it('falls back to full URL as title for unrecognized URLs', () => {
+    const url = 'https://example.com/some-issue'
+    expect(parseIssueUrl(url)).toEqual({ title: url, externalUrl: url })
+  })
+
+  it('always stores the original URL as externalUrl', () => {
+    const url = 'https://github.com/org/repo/issues/1'
+    expect(parseIssueUrl(url).externalUrl).toBe(url)
+  })
+})
+
+describe('parseIssueUrls', () => {
+  it('parses multiple URLs from multiline text', () => {
+    const text = [
+      'https://github.com/org/repo/issues/1',
+      'https://linear.app/team/issue/ENG-2',
+      'https://corp.atlassian.net/browse/PROJ-3',
+    ].join('\n')
+    expect(parseIssueUrls(text)).toEqual([
+      { title: 'org/repo #1', externalUrl: 'https://github.com/org/repo/issues/1' },
+      { title: 'ENG-2', externalUrl: 'https://linear.app/team/issue/ENG-2' },
+      { title: 'PROJ-3', externalUrl: 'https://corp.atlassian.net/browse/PROJ-3' },
+    ])
+  })
+
+  it('ignores empty lines', () => {
+    const text = 'https://github.com/org/repo/issues/1\n\n   \nhttps://github.com/org/repo/issues/2'
+    expect(parseIssueUrls(text)).toHaveLength(2)
+  })
+
+  it('ignores whitespace-only lines', () => {
+    const text = '  \n\t\n  '
+    expect(parseIssueUrls(text)).toHaveLength(0)
+  })
+
+  it('returns empty array for empty input', () => {
+    expect(parseIssueUrls('')).toEqual([])
+  })
+
+  it('preserves order of URLs', () => {
+    const text = 'https://github.com/a/b/issues/1\nhttps://github.com/c/d/issues/2'
+    const result = parseIssueUrls(text)
+    expect(result[0].title).toBe('a/b #1')
+    expect(result[1].title).toBe('c/d #2')
+  })
+})

--- a/src/lib/parseIssueUrl.ts
+++ b/src/lib/parseIssueUrl.ts
@@ -1,0 +1,36 @@
+export interface ParsedIssue {
+  title: string
+  externalUrl: string
+}
+
+export function parseIssueUrl(raw: string): ParsedIssue {
+  const url = raw.trim()
+
+  // GitHub: github.com/org/repo/issues/123
+  const githubMatch = url.match(/github\.com\/([^/?#]+\/[^/?#]+)\/issues\/(\d+)/i)
+  if (githubMatch) {
+    return { title: `${githubMatch[1]} #${githubMatch[2]}`, externalUrl: url }
+  }
+
+  // Linear: linear.app/team/issue/KEY-456 or linear.app/team/issues/KEY-456
+  const linearMatch = url.match(/linear\.app\/[^/?#]+\/issues?\/([A-Z]+-\d+)/i)
+  if (linearMatch) {
+    return { title: linearMatch[1].toUpperCase(), externalUrl: url }
+  }
+
+  // Jira/Atlassian: *.atlassian.net/browse/KEY-456
+  const jiraMatch = url.match(/atlassian\.net\/browse\/([A-Z]+-\d+)/i)
+  if (jiraMatch) {
+    return { title: jiraMatch[1].toUpperCase(), externalUrl: url }
+  }
+
+  return { title: url, externalUrl: url }
+}
+
+export function parseIssueUrls(text: string): ParsedIssue[] {
+  return text
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .map(parseIssueUrl)
+}

--- a/src/pages/SessionDetail.tsx
+++ b/src/pages/SessionDetail.tsx
@@ -9,6 +9,7 @@ import type { Issue } from '../hooks/useIssues'
 import { roundUpToFibonacci } from '../lib/fibonacci'
 import { getProfileLabel, VOTE_VALUES, SCORING_PROFILE_OPTIONS } from '../lib/scoringProfiles'
 import type { ScoringProfile } from '../lib/scoringProfiles'
+import { parseIssueUrls } from '../lib/parseIssueUrl'
 
 export default function SessionDetail() {
   const { sessionId } = useParams<{ sessionId: string }>()
@@ -16,7 +17,7 @@ export default function SessionDetail() {
   const [searchParams, setSearchParams] = useSearchParams()
   const { user } = useAuth()
   const { session, loading: sessionLoading, error: sessionError } = useSession(sessionId)
-  const { issues, loading: issuesLoading, error: issuesError, addIssue, deleteIssue, castVote, revealVotes, reopenIssue } =
+  const { issues, loading: issuesLoading, error: issuesError, addIssue, addIssues, deleteIssue, castVote, revealVotes, reopenIssue } =
     useIssues(sessionId, user)
 
   const [showAddModal, setShowAddModal] = useState(false)
@@ -33,6 +34,10 @@ export default function SessionDetail() {
   const [generatingToken, setGeneratingToken] = useState(false)
   const [showProfileModal, setShowProfileModal] = useState(false)
   const [pendingProfile, setPendingProfile] = useState<ScoringProfile>('fibonacci')
+  const [showFromLinksModal, setShowFromLinksModal] = useState(false)
+  const [linkInput, setLinkInput] = useState('')
+  const [fromLinksAdding, setFromLinksAdding] = useState(false)
+  const [fromLinksError, setFromLinksError] = useState<string | null>(null)
 
   const isOwner = user && session && session.creator_uid === user.uid
   const isMember = user && session ? session.memberIds.includes(user.uid) : false
@@ -139,6 +144,28 @@ export default function SessionDetail() {
     setShowProfileModal(false)
   }
 
+  function openFromLinksModal() {
+    setLinkInput('')
+    setFromLinksError(null)
+    setShowFromLinksModal(true)
+  }
+
+  async function handleAddFromLinks() {
+    const items = parseIssueUrls(linkInput)
+    if (items.length === 0) return
+    setFromLinksAdding(true)
+    setFromLinksError(null)
+    try {
+      await addIssues(items)
+      setLinkInput('')
+      setShowFromLinksModal(false)
+    } catch {
+      setFromLinksError('Failed to add issues. Please try again.')
+    } finally {
+      setFromLinksAdding(false)
+    }
+  }
+
   if (sessionLoading) {
     return (
       <div style={{ minHeight: '100vh', backgroundColor: 'var(--color-bg-page)', padding: '2rem' }}>
@@ -239,6 +266,23 @@ export default function SessionDetail() {
                 }}
               >
                 Invite
+              </button>
+            )}
+            {isOwner && (
+              <button
+                onClick={openFromLinksModal}
+                style={{
+                  backgroundColor: 'transparent',
+                  color: 'var(--color-text-secondary)',
+                  border: '1px solid var(--color-border-default)',
+                  borderRadius: '0.5rem',
+                  padding: '0.5rem 1rem',
+                  fontSize: '0.875rem',
+                  fontWeight: 500,
+                  cursor: 'pointer',
+                }}
+              >
+                Add from links
               </button>
             )}
             {isOwner && (
@@ -619,6 +663,114 @@ export default function SessionDetail() {
               >
                 {adding ? 'Adding…' : 'Add'}
               </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Add from links modal */}
+      {showFromLinksModal && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="Add issues from links"
+          onClick={(e) => { if (e.target === e.currentTarget) setShowFromLinksModal(false) }}
+          style={{
+            position: 'fixed',
+            inset: 0,
+            backgroundColor: 'var(--color-overlay)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            zIndex: 50,
+          }}
+        >
+          <div
+            style={{
+              backgroundColor: 'var(--color-bg-elevated)',
+              border: '1px solid var(--color-border-default)',
+              borderRadius: '0.75rem',
+              padding: '1.5rem',
+              width: '100%',
+              maxWidth: '520px',
+            }}
+          >
+            <h2 style={{ margin: '0 0 0.375rem 0', fontSize: '1.125rem', fontWeight: 600, color: 'var(--color-text-primary)' }}>
+              Add issues from links
+            </h2>
+            <p style={{ margin: '0 0 1rem 0', fontSize: '0.8125rem', color: 'var(--color-text-secondary)' }}>
+              Paste one URL per line. GitHub, Linear, and Jira links are recognized automatically.
+            </p>
+            <textarea
+              autoFocus
+              placeholder={'https://github.com/org/repo/issues/123\nhttps://linear.app/team/issue/ENG-456\nhttps://corp.atlassian.net/browse/PROJ-789'}
+              value={linkInput}
+              onChange={(e) => setLinkInput(e.target.value)}
+              rows={6}
+              style={{
+                display: 'block',
+                width: '100%',
+                boxSizing: 'border-box',
+                padding: '0.625rem 0.75rem',
+                marginBottom: fromLinksError ? '0.75rem' : '1rem',
+                backgroundColor: 'var(--color-bg-surface)',
+                border: '1px solid var(--color-border-default)',
+                borderRadius: '0.5rem',
+                color: 'var(--color-text-primary)',
+                fontSize: '0.8125rem',
+                outline: 'none',
+                resize: 'vertical',
+                fontFamily: 'inherit',
+              }}
+            />
+            {fromLinksError && (
+              <p style={{ margin: '0 0 1rem 0', fontSize: '0.8125rem', color: 'var(--color-error)' }}>
+                {fromLinksError}
+              </p>
+            )}
+            <div style={{ display: 'flex', gap: '0.75rem', justifyContent: 'flex-end' }}>
+              <button
+                onClick={() => setShowFromLinksModal(false)}
+                disabled={fromLinksAdding}
+                style={{
+                  padding: '0.5rem 1rem',
+                  border: '1px solid var(--color-border-default)',
+                  borderRadius: '0.5rem',
+                  backgroundColor: 'transparent',
+                  color: 'var(--color-text-secondary)',
+                  fontSize: '0.875rem',
+                  cursor: fromLinksAdding ? 'not-allowed' : 'pointer',
+                }}
+              >
+                Cancel
+              </button>
+              {(() => {
+                const count = parseIssueUrls(linkInput).length
+                const disabled = count === 0 || fromLinksAdding
+                const label = fromLinksAdding
+                  ? 'Adding…'
+                  : count === 0
+                    ? 'Add Issues'
+                    : `Add ${count} Issue${count === 1 ? '' : 's'}`
+                return (
+                  <button
+                    onClick={handleAddFromLinks}
+                    disabled={disabled}
+                    style={{
+                      padding: '0.5rem 1rem',
+                      border: 'none',
+                      borderRadius: '0.5rem',
+                      backgroundColor: disabled ? 'var(--color-bg-surface)' : 'var(--color-primary)',
+                      color: disabled ? 'var(--color-text-muted)' : 'var(--color-text-inverse)',
+                      fontSize: '0.875rem',
+                      fontWeight: 500,
+                      cursor: disabled ? 'not-allowed' : 'pointer',
+                    }}
+                  >
+                    {label}
+                  </button>
+                )
+              })()}
             </div>
           </div>
         </div>


### PR DESCRIPTION
Implements #156 - Add Issues from Links.

Users can paste one URL per line into a new "Add from links" modal. Each non-empty line becomes an issue, with the title derived from recognized URL patterns (GitHub, Linear, Jira) and the original URL stored as `externalUrl`.

**Changes:**
- `src/lib/parseIssueUrl.ts`: URL parser with GitHub, Linear, Atlassian support and fallback
- `src/lib/parseIssueUrl.test.ts`: 12 Vitest unit tests
- `src/hooks/useIssues.ts`: new `addIssues()` batch Firestore write
- `src/pages/SessionDetail.tsx`: "Add from links" button + modal

Generated with [Claude Code](https://claude.ai/code)