### PR TITLE
fix: add vercel.json to handle SPA client-side routing

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
Adds a `vercel.json` with a catch-all rewrite rule so Vercel serves `index.html` for every route, letting React Router handle navigation client-side.

Fixes direct URL navigation and hard refresh returning 404 on all routes except `/`.

Closes #160

Generated with [Claude Code](https://claude.ai/code)